### PR TITLE
Add test_coverage MCP tool with uncovered lines and statistics

### DIFF
--- a/app/Assist/AI/Mcp/McpElements.php
+++ b/app/Assist/AI/Mcp/McpElements.php
@@ -536,6 +536,57 @@ class McpElements
 	}
 
 	/**
+	 * Runs PHPUnit with code coverage and returns per-file statistics and uncovered lines.
+	 *
+	 * Requires Xdebug or PCOV to be enabled. Files are sorted by line coverage
+	 * percentage ascending so the worst-covered files appear first.
+	 *
+	 * @param string $filter  optional PHPUnit filter expression
+	 * @param int    $maxPct  only include files strictly below this line-coverage % (0–100); 100 = include all
+	 */
+	#[McpTool('test_coverage', 'Runs PHPUnit with code coverage. Returns line/method/class stats and uncovered lines per file, sorted worst first.')]
+	public function testCoverageTool(string $filter = '', int $maxPct = 100): CallToolResult
+	{
+		$parsed = $this->shell->phpunitCoverageParsed($filter);
+
+		$stats = $parsed['stats'];
+		$files = $parsed['files'];
+
+		if ($maxPct < 100) {
+			$files = array_values(array_filter($files, static fn (array $f): bool => $f['lines_pct'] < $maxPct));
+		}
+
+		$summaryText = [] !== $stats
+			? sprintf(
+				'Coverage — Lines: %.2f%% (%d/%d) | Methods: %.2f%% (%d/%d) | Classes: %.2f%% (%d/%d)',
+				$stats['lines_pct'],
+				$stats['lines_covered'],
+				$stats['lines_total'],
+				$stats['methods_pct'],
+				$stats['methods_covered'],
+				$stats['methods_total'],
+				$stats['classes_pct'],
+				$stats['classes_covered'],
+				$stats['classes_total'],
+			)
+			: 'No coverage data available (Xdebug/PCOV required)';
+
+		$result = new CallToolResult(
+			[new TextContent($summaryText)],
+			structuredContent: [
+				'ok' => $parsed['ok'],
+				'tests_summary' => $parsed['summary'],
+				'stats' => $stats,
+				'files' => $files,
+			],
+		);
+
+		$this->observer->log('test_coverage', ['filter' => $filter, 'maxPct' => $maxPct], $summaryText);
+
+		return $result;
+	}
+
+	/**
 	 * Runs PHPStan, PHPUnit, and PHP-CS-Fixer sequentially.
 	 *
 	 * Each tool runs as a separate child process. Output is capped per tool

--- a/app/Assist/AI/Mcp/Shell.php
+++ b/app/Assist/AI/Mcp/Shell.php
@@ -254,6 +254,132 @@ final class Shell
 	}
 
 	/**
+	 * Runs PHPUnit with Clover XML coverage output to a temporary file.
+	 *
+	 * @param string $filter PHPUnit --filter value; empty = run all
+	 *
+	 * @return array{output: string, exitCode: int, cloverPath: string}
+	 */
+	public function phpunitCoverage(string $filter = ''): array
+	{
+		$cloverPath = sys_get_temp_dir() . '/phpunit_coverage.xml';
+		$filterArg = '' !== $filter ? ' --filter=' . escapeshellarg($filter) : '';
+
+		$result = $this->run(
+			'php vendor/bin/phpunit' . $filterArg
+			. ' --exclude-group=integration --no-progress --colors=never'
+			. ' --coverage-clover=' . escapeshellarg($cloverPath)
+		);
+
+		return $result + ['cloverPath' => $cloverPath];
+	}
+
+	/**
+	 * Runs PHPUnit with coverage and returns parsed statistics and uncovered lines.
+	 *
+	 * @param string $filter PHPUnit --filter value; empty = run all
+	 *
+	 * @return array{ok: bool, summary: string, stats: array<string, mixed>, files: array<int, array<string, mixed>>}
+	 */
+	public function phpunitCoverageParsed(string $filter = ''): array
+	{
+		['output' => $output, 'cloverPath' => $cloverPath] = $this->phpunitCoverage($filter);
+
+		$base = self::parsePhpunitOutput($output);
+		$coverage = self::parseCloverXml($cloverPath);
+
+		return [
+			'ok' => $base['ok'],
+			'summary' => $base['summary'],
+			'stats' => $coverage['stats'],
+			'files' => $coverage['files'],
+		];
+	}
+
+	/**
+	 * Parses a PHPUnit Clover XML file into summary stats and per-file uncovered lines.
+	 *
+	 * Files are sorted by line coverage percentage ascending (worst coverage first).
+	 *
+	 * @return array{stats: array<string, mixed>, files: array<int, array<string, mixed>>}
+	 */
+	public static function parseCloverXml(string $path): array
+	{
+		if (!is_file($path)) {
+			return ['stats' => [], 'files' => []];
+		}
+
+		$xml = simplexml_load_file($path);
+
+		if (false === $xml) {
+			return ['stats' => [], 'files' => []];
+		}
+
+		$root = rtrim((string) Path::getRootDir(), '/') . '/';
+
+		// Overall project metrics
+		$stats = [];
+		$metrics = $xml->project->metrics ?? null;
+
+		if (null !== $metrics) {
+			$totalStmts = (int) $metrics['statements'];
+			$coveredStmts = (int) $metrics['coveredstatements'];
+			$totalMethods = (int) $metrics['methods'];
+			$coveredMethods = (int) $metrics['coveredmethods'];
+			$totalClasses = (int) $metrics['classes'];
+			$coveredClasses = (int) $metrics['coveredclasses'];
+
+			$stats = [
+				'lines_pct' => $totalStmts > 0 ? round($coveredStmts / $totalStmts * 100, 2) : 0.0,
+				'lines_covered' => $coveredStmts,
+				'lines_total' => $totalStmts,
+				'methods_pct' => $totalMethods > 0 ? round($coveredMethods / $totalMethods * 100, 2) : 0.0,
+				'methods_covered' => $coveredMethods,
+				'methods_total' => $totalMethods,
+				'classes_pct' => $totalClasses > 0 ? round($coveredClasses / $totalClasses * 100, 2) : 0.0,
+				'classes_covered' => $coveredClasses,
+				'classes_total' => $totalClasses,
+			];
+		}
+
+		// Per-file breakdown
+		$files = [];
+
+		foreach ($xml->project->file ?? [] as $file) {
+			$filePath = str_replace($root, '', (string) $file['name']);
+			$uncoveredLines = [];
+
+			foreach ($file->line ?? [] as $line) {
+				if ('stmt' === (string) $line['type'] && 0 === (int) $line['count']) {
+					$uncoveredLines[] = (int) $line['num'];
+				}
+			}
+
+			$fileMetrics = $file->metrics ?? null;
+
+			if (null === $fileMetrics) {
+				continue;
+			}
+
+			$stmts = (int) $fileMetrics['statements'];
+			$covered = (int) $fileMetrics['coveredstatements'];
+			$pct = $stmts > 0 ? round($covered / $stmts * 100, 2) : 100.0;
+
+			$files[] = [
+				'file' => $filePath,
+				'lines_pct' => $pct,
+				'lines_covered' => $covered,
+				'lines_total' => $stmts,
+				'uncovered_lines' => $uncoveredLines,
+			];
+		}
+
+		usort($files, static fn (array $a, array $b): int => $a['lines_pct'] <=> $b['lines_pct']);
+
+		return ['stats' => $stats, 'files' => $files];
+	}
+
+	/**
 	 * Parses raw PHPUnit output into ok/summary.
 	 *
 	 * @return array{ok: bool, summary: string}


### PR DESCRIPTION
- Shell: add phpunitCoverage(), phpunitCoverageParsed(), parseCloverXml()
  - Runs PHPUnit with --coverage-clover to a temp file
  - Parses overall line/method/class percentages from project metrics
  - Extracts uncovered statement lines per file; sorts files worst-first
- McpElements: add testCoverageTool() exposed as 'test_coverage'
  - Parameters: filter (PHPUnit filter), maxPct (exclude fully-covered files)
  - Returns structured content with stats + per-file uncovered_lines[]

https://claude.ai/code/session_01E761js4xKqWqbMFFBhPJTv